### PR TITLE
Allow custom attributes

### DIFF
--- a/toolbar.js
+++ b/toolbar.js
@@ -198,7 +198,7 @@ var RevealToolbar =
         }
 
         if (custom) {
-          custom.forEach(element => createContainerButton(element.icon, element.callback element?.attrs));
+          custom.forEach(element => createContainerButton(element.icon, element.callback, element?.attrs));
         }
         if (captureMenu) {
           // handle async loading of plugins

--- a/toolbar.js
+++ b/toolbar.js
@@ -116,13 +116,16 @@ var RevealToolbar =
           position == 'top' ? 'reveal-toolbar-top' : 'reveal-toolbar-bottom'
         );
 
-        function createContainerButton(icon, cb, container = dom.toolbar) {
+        function createContainerButton(icon, cb, attrs = {}, container = dom.toolbar) {
           var button = createNode(
             container,
             'a',
             'reveal-toolbar-button',
             null
           );
+          for (const [key, value] of Object.entries(attrs)) {
+            button.setAttribute(key, value);
+          }
           button.setAttribute('href', '#');
           button.onclick = function(event) {
             event.preventDefault();
@@ -195,7 +198,7 @@ var RevealToolbar =
         }
 
         if (custom) {
-          custom.forEach(element => createContainerButton(element.icon, element.callback));
+          custom.forEach(element => createContainerButton(element.icon, element.callback element?.attrs));
         }
         if (captureMenu) {
           // handle async loading of plugins


### PR DESCRIPTION
Custom toolbar elements can now pass in an `attrs` option. For example:

```js
{ icon: 'fa-play', callback: play, attrs: { key1: 'val1', key2: 'val2' } }
```